### PR TITLE
Stringify data optional

### DIFF
--- a/src/providers/oauth-provider.js
+++ b/src/providers/oauth-provider.js
@@ -10,6 +10,7 @@ var defaults = {
   baseUrl: null,
   clientId: null,
   clientSecret: null,
+  stringifyData: true,
   grantPath: '/oauth2/token',
   revokePath: '/oauth2/revoke'
 };
@@ -120,7 +121,9 @@ function OAuthProvider() {
           data.client_secret = config.clientSecret;
         }
 
-        data = queryString.stringify(data);
+        if(config.stringifyData){
+            data = queryString.stringify(data);
+        }
 
         options = angular.extend({
           headers: {
@@ -156,7 +159,9 @@ function OAuthProvider() {
           data.client_secret = config.clientSecret;
         }
 
-        data = queryString.stringify(data);
+        if(config.stringifyData){
+            data = queryString.stringify(data);
+        }
 
         options = angular.extend({
           headers: {
@@ -194,7 +199,9 @@ function OAuthProvider() {
           data.client_secret = config.clientSecret;
         }
 
-        data = queryString.stringify(data);
+        if(config.stringifyData){
+            data = queryString.stringify(data);
+        }
 
         options = angular.extend({
           headers: {


### PR DESCRIPTION
Making optional serialization of data provides a greater number of possibilities to work with authentication APIs.