### PR TITLE
add two optional property for OAuth configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ angular.module('myApp', ['angular-oauth2'])
     OAuth.configure({
       baseUrl: 'https://api.website.com',
       clientId: 'CLIENT_ID',
-      clientSecret: 'CLIENT_SECRET' // optional
+      clientSecret: 'CLIENT_SECRET', // optional
+      isCookiePathRoot: false,       // optional, when the property value is false or not set, the path of cookie is default, when the property value is true, the cookie path is root.
+      secure: true                 // optional, when the property value is true or not set, this component can only used in https protocol, that is if you want to use this in http environment please set it to false.
     });
   }]);
 ```

--- a/dist/angular-oauth2.js
+++ b/dist/angular-oauth2.js
@@ -128,6 +128,12 @@
                                 "Content-Type": "application/x-www-form-urlencoded"
                             }
                         }, options);
+						if (this.config.isCookiePathRoot != null && this.config.isCookiePathRoot) {
+                        	OAuthToken.setCookiePathRoot();
+                        }
+						if (this.config.secure != null && !this.config.secure) {
+                        	OAuthToken.setSecurity(this.config.secure);
+                        }
                         return $http.post("" + this.config.baseUrl + this.config.grantPath, data, options).then(function(response) {
                             OAuthToken.setToken(response.data);
                             return response;
@@ -227,6 +233,16 @@
                     _classCallCheck(this, OAuthToken);
                 }
                 _createClass(OAuthToken, [ {
+                	key: "setCookiePathRoot",
+                	value: function setCookiePathRoot() {
+                		config.options.path = "/";
+                	}
+                },{
+                	key: "setSecurity",
+                	value: function setSecurity(secure) {
+                		config.options.secure = secure;
+                	}
+                },{
                     key: "setToken",
                     value: function setToken(data) {
                         return $cookies.putObject(config.name, data, config.options);


### PR DESCRIPTION
add two optional property for OAuth.configure:
isCookiePathRoot: false,       // optional, when the property value is false or not set, the path of cookie is default, when the property value is true, the cookie path is root. (when two different web application use the same login web app and permissions system, the token should be transmit, so need set cookie path root. )
secure: true                 // optional, when the property value is true or not set, this component can only used in https protocol, that is if you want to use this in http environment please set it to false.
