### PR TITLE
add two optional property for OAuth.configure/ add 403 error interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ angular.module('myApp', ['angular-oauth2'])
     OAuth.configure({
       baseUrl: 'https://api.website.com',
       clientId: 'CLIENT_ID',
-      clientSecret: 'CLIENT_SECRET' // optional
+      clientSecret: 'CLIENT_SECRET', // optional
+      isCookiePathRoot: false,       // optional, when the property value is false or not set, the path of cookie is default, when the property value is true, the cookie path is root.
+      secure: true                 // optional, when the property value is true or not set, this component can only used in https protocol, that is if you want to use this in http environment please set it to false.
     });
   }]);
 ```

--- a/src/interceptors/oauth-interceptor.js
+++ b/src/interceptors/oauth-interceptor.js
@@ -33,9 +33,10 @@ function oauthInterceptor($q, $rootScope, OAuthToken) {
       ) {
         $rootScope.$emit('oauth:error', rejection);
       }
-	  if (403 === rejection.status && rejection.data && 'access_denied' === rejection.data.error) {
-		$rootScope.$emit('oauth:error', rejection);
-	  }
+
+      if (403 === rejection.status && rejection.data && 'access_denied' === rejection.data.error) {
+        $rootScope.$emit('oauth:error', rejection);
+      }
 
       return $q.reject(rejection);
     }

--- a/src/interceptors/oauth-interceptor.js
+++ b/src/interceptors/oauth-interceptor.js
@@ -33,6 +33,9 @@ function oauthInterceptor($q, $rootScope, OAuthToken) {
       ) {
         $rootScope.$emit('oauth:error', rejection);
       }
+	  if (403 === rejection.status && rejection.data && 'access_denied' === rejection.data.error) {
+		$rootScope.$emit('oauth:error', rejection);
+	  }
 
       return $q.reject(rejection);
     }

--- a/src/providers/oauth-provider.js
+++ b/src/providers/oauth-provider.js
@@ -139,6 +139,13 @@ function OAuthProvider() {
           }
         }, options);
 
+		if (typeof this.config.isCookiePathRoot !== 'undefined' && this.config.isCookiePathRoot === true) {
+			OAuthToken.setCookiePathRoot();
+		}
+		if (typeof this.config.secure !== 'undefined' && !this.config.secure) {
+			OAuthToken.setSecurity(this.config.secure);
+		}
+
         return $http.post(`${this.config.baseUrl}${this.config.grantPath}`, data, options).then((response) => {
           OAuthToken.setToken(response.data);
 

--- a/src/providers/oauth-provider.js
+++ b/src/providers/oauth-provider.js
@@ -139,12 +139,13 @@ function OAuthProvider() {
           }
         }, options);
 
-		if (typeof this.config.isCookiePathRoot !== 'undefined' && this.config.isCookiePathRoot === true) {
-			OAuthToken.setCookiePathRoot();
-		}
-		if (typeof this.config.secure !== 'undefined' && !this.config.secure) {
-			OAuthToken.setSecurity(this.config.secure);
-		}
+        if (typeof this.config.isCookiePathRoot !== 'undefined' && this.config.isCookiePathRoot === true) {
+          OAuthToken.setCookiePathRoot();
+        }
+
+        if (typeof this.config.secure !== 'undefined' && !this.config.secure) {
+          OAuthToken.setSecurity(this.config.secure);
+        }
 
         return $http.post(`${this.config.baseUrl}${this.config.grantPath}`, data, options).then((response) => {
           OAuthToken.setToken(response.data);

--- a/src/providers/oauth-token-provider.js
+++ b/src/providers/oauth-token-provider.js
@@ -42,6 +42,22 @@ function OAuthTokenProvider() {
   this.$get = function($cookies) {
     class OAuthToken {
 
+	  /**
+       * Set Cookie Path Root.
+       */
+
+      setCookiePathRoot() {
+        config.options.path = '/';
+      }
+
+	  /**
+       * Set Secure.
+       */
+
+      setSecurity(secure) {
+        config.options.secure = secure;
+      }
+
       /**
        * Set token.
        */

--- a/src/providers/oauth-token-provider.js
+++ b/src/providers/oauth-token-provider.js
@@ -42,7 +42,7 @@ function OAuthTokenProvider() {
   this.$get = function($cookies) {
     class OAuthToken {
 
-	  /**
+      /**
        * Set Cookie Path Root.
        */
 
@@ -50,7 +50,7 @@ function OAuthTokenProvider() {
         config.options.path = '/';
       }
 
-	  /**
+      /**
        * Set Secure.
        */
 


### PR DESCRIPTION
add two optional property for OAuth.configure:
isCookiePathRoot: false, // optional, when the property value is false or not set, the path of cookie is default, when the property value is true, the cookie path is root. (when two different web application use the same login web app and permissions system, the token should be transmit, so need set cookie path root. )
secure: true // optional, when the property value is true or not set, this component can only used in https protocol, that is if you want to use this in http environment please set it to false.