### PR TITLE
Add option to send client credentials (client_id and client_secret) in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ OAuthProvider.configure({
   clientId: null,
   clientSecret: null,
   grantPath: '/oauth2/token',
-  revokePath: '/oauth2/revoke',
-  clientCredentials: 'body'
+  revokePath: '/oauth2/revoke'
 });
 ```
 
@@ -118,8 +117,7 @@ OAuth.configure({
   clientId: null,
   clientSecret: null,
   grantPath: '/oauth2/token',
-  revokePath: '/oauth2/revoke',
-  clientCredentials: 'body'
+  revokePath: '/oauth2/revoke'
 });
 
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ OAuthProvider.configure({
   clientId: null,
   clientSecret: null,
   grantPath: '/oauth2/token',
-  revokePath: '/oauth2/revoke'
+  revokePath: '/oauth2/revoke',
+  clientCredentials: 'body'
 });
 ```
 
@@ -117,7 +118,8 @@ OAuth.configure({
   clientId: null,
   clientSecret: null,
   grantPath: '/oauth2/token',
-  revokePath: '/oauth2/revoke'
+  revokePath: '/oauth2/revoke',
+  clientCredentials: 'body'
 });
 
 ```

--- a/dist/angular-oauth2.js
+++ b/dist/angular-oauth2.js
@@ -95,32 +95,6 @@
             }
             return config;
         };
-        var addCredentialsInHeader = function addCredentialsInHeader(config, options) {
-            credentials = config.clientId + ":";
-            if (null !== config.clientSecret) {
-                credentials += config.clientSecret;
-            }
-            credentials = "Basic " + btoa(credentials);
-
-            options = angular.extend({
-                headers: {
-                    Authorization: credentials,
-                    "Content-Type": "application/x-www-form-urlencoded"
-                }
-            }, options);
-
-            return options;
-        };
-        var addCredentialsInBody = function addCredentialsInBody(config, data) {
-            data = angular.extend({
-                client_id: config.clientId
-            }, data);
-            if (null !== config.clientSecret) {
-                data.client_secret = config.clientSecret;
-            }
-
-            return data;
-        };
         this.configure = function(params) {
             _this.defaultConfig = sanitizeConfigParams(params);
         };
@@ -143,22 +117,20 @@
                 }, {
                     key: "getAccessToken",
                     value: function getAccessToken(data, options) {
-                        if ("header" === this.config.clientCredentials) {
-                            options = addCredentialsInHeader(this.config, options);
-                        } else {
-                            data = addCredentialsInBody(this.config, data);
-                            options = angular.extend({
-                                headers: {
-                                    Authorization: undefined,
-                                    "Content-Type": "application/x-www-form-urlencoded"
-                                }
-                            }, options);
-                        }
-
                         data = angular.extend({
+                            client_id: this.config.clientId,
                             grant_type: "password"
                         }, data);
+                        if (null !== this.config.clientSecret) {
+                            data.client_secret = this.config.clientSecret;
+                        }
                         data = queryString.stringify(data);
+                        options = angular.extend({
+                            headers: {
+                                Authorization: undefined,
+                                "Content-Type": "application/x-www-form-urlencoded"
+                            }
+                        }, options);
                         return $http.post("" + this.config.baseUrl + this.config.grantPath, data, options).then(function(response) {
                             OAuthToken.setToken(response.data);
                             return response;
@@ -167,23 +139,21 @@
                 }, {
                     key: "getRefreshToken",
                     value: function getRefreshToken(data, options) {
-                        if ("header" === this.config.clientCredentials) {
-                            options = addCredentialsInHeader(this.config, options);
-                        } else {
-                            data = addCredentialsInBody(this.config, data);
-                            options = angular.extend({
-                                headers: {
-                                    Authorization: undefined,
-                                    "Content-Type": "application/x-www-form-urlencoded"
-                                }
-                            }, options);
-                        }
-
                         data = angular.extend({
+                            client_id: this.config.clientId,
                             grant_type: "refresh_token",
                             refresh_token: OAuthToken.getRefreshToken()
                         }, data);
+                        if (null !== this.config.clientSecret) {
+                            data.client_secret = this.config.clientSecret;
+                        }
                         data = queryString.stringify(data);
+                        options = angular.extend({
+                            headers: {
+                                Authorization: undefined,
+                                "Content-Type": "application/x-www-form-urlencoded"
+                            }
+                        }, options);
                         return $http.post("" + this.config.baseUrl + this.config.grantPath, data, options).then(function(response) {
                             OAuthToken.setToken(response.data);
                             return response;
@@ -192,23 +162,21 @@
                 }, {
                     key: "revokeToken",
                     value: function revokeToken(data, options) {
-                        if ("header" === this.config.clientCredentials) {
-                            options = addCredentialsInHeader(this.config, options);
-                        } else {
-                            data = addCredentialsInBody(this.config, data);
-                            options = angular.extend({
-                                headers: {
-                                    "Content-Type": "application/x-www-form-urlencoded"
-                                }
-                            }, options);
-                        }
-
                         var refreshToken = OAuthToken.getRefreshToken();
                         data = angular.extend({
+                            client_id: this.config.clientId,
                             token: refreshToken ? refreshToken : OAuthToken.getAccessToken(),
                             token_type_hint: refreshToken ? "refresh_token" : "access_token"
                         }, data);
+                        if (null !== this.config.clientSecret) {
+                            data.client_secret = this.config.clientSecret;
+                        }
                         data = queryString.stringify(data);
+                        options = angular.extend({
+                            headers: {
+                                "Content-Type": "application/x-www-form-urlencoded"
+                            }
+                        }, options);
                         return $http.post("" + this.config.baseUrl + this.config.revokePath, data, options).then(function(response) {
                             OAuthToken.removeToken();
                             return response;


### PR DESCRIPTION
The RFC 6749 about OAuth 2.0 (https://tools.ietf.org/html/rfc6749#section-2.3.1) mentions the following:
"Including the client credentials in the request-body using the two
   parameters is NOT RECOMMENDED and SHOULD be limited to clients unable
   to directly utilize the HTTP Basic authentication scheme (or other
   password-based HTTP authentication schemes).  The parameters can only
   be transmitted in the request-body and MUST NOT be included in the
   request URI."

In order to be conform with this RFC, this pull request proposes to add an option "clientCredentials" which will send the client_id and client_secret in the Authorization header when the value is equal to "header".