### PR TITLE
Prevent loading angular multiple times with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
     "url": "https://github.com/seegno/angular-oauth2/issues"
   },
   "homepage": "https://github.com/seegno/angular-oauth2",
-  "dependencies": {
-    "angular": "1.5.9",
-    "angular-cookies": "1.5.9",
-    "query-string": "^1.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "angular": "^1.5.9",
+    "angular-cookies": "^1.5.9",
+    "query-string": "^1.0.0",
     "angular-mocks": "1.5.9",
     "github-changes": "^1.0.0",
     "gulp": "^3.8.10",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "devDependencies": {
     "angular": "^1.5.9",
     "angular-cookies": "^1.5.9",
-    "query-string": "^1.0.0",
     "angular-mocks": "1.5.9",
+    "browserify": "^14.5.0",
     "github-changes": "^1.0.0",
     "gulp": "^3.8.10",
     "gulp-babel": "^5.3.0",
@@ -38,7 +38,7 @@
     "gulp-wrap-umd": "^0.2.1",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.13.0",
-    "karma-browserify": "^2.0.0",
+    "karma-browserify": "^5.1.2",
     "karma-chrome-launcher": "^0.1.7",
     "karma-firefox-launcher": "^0.1.4",
     "karma-mocha": "^0.1.10",
@@ -47,8 +47,10 @@
     "karma-sinon": "^1.0.4",
     "lodash": "^4.0.0",
     "mocha": "^2.4.5",
+    "query-string": "^1.0.0",
     "should": "^4.6.0",
     "sinon": "^1.17.3",
+    "watchify": "^3.9.0",
     "yargs": "^3.6.0"
   },
   "scripts": {

--- a/test/unit/interceptors/oauth-interceptor.spec.js
+++ b/test/unit/interceptors/oauth-interceptor.spec.js
@@ -64,7 +64,8 @@ describe('oauthInterceptor', function() {
 
     $httpBackend.expectGET('https://website.com').respond(400, { error: 'invalid_request' });
 
-    $http.get('https://website.com');
+    $http.get('https://website.com')
+      .catch(() => { });
 
     $httpBackend.flush();
 
@@ -77,7 +78,8 @@ describe('oauthInterceptor', function() {
 
     $httpBackend.expectGET('https://website.com').respond(400, { error: 'invalid_request' });
 
-    $http.get('https://website.com');
+    $http.get('https://website.com')
+      .catch(() => { });
 
     $httpBackend.flush();
 
@@ -93,7 +95,8 @@ describe('oauthInterceptor', function() {
 
     $httpBackend.expectGET('https://website.com').respond(400, { error: 'invalid_grant' });
 
-    $http.get('https://website.com');
+    $http.get('https://website.com')
+      .catch(() => { });
 
     $httpBackend.flush();
 
@@ -106,7 +109,8 @@ describe('oauthInterceptor', function() {
 
     $httpBackend.expectGET('https://website.com').respond(400, { error: 'invalid_grant' });
 
-    $http.get('https://website.com');
+    $http.get('https://website.com')
+      .catch(() => { });
 
     $httpBackend.flush();
 
@@ -122,7 +126,8 @@ describe('oauthInterceptor', function() {
 
     $httpBackend.expectGET('https://website.com').respond(401, { error: 'invalid_token' });
 
-    $http.get('https://website.com');
+    $http.get('https://website.com')
+      .catch(() => { });
 
     $httpBackend.flush();
 
@@ -138,7 +143,8 @@ describe('oauthInterceptor', function() {
 
     $httpBackend.expectGET('https://website.com').respond(401, null, { 'www-authenticate': 'Bearer realm="example"' });
 
-    $http.get('https://website.com');
+    $http.get('https://website.com')
+      .catch(() => { });
 
     $httpBackend.flush();
 


### PR DESCRIPTION
Dependencies were unlocked and moved to devDependencies, fixes #123 
Update browserify fixes #126 
Also fixes tests to work with newest Chrome version.
  